### PR TITLE
Update example2.c

### DIFF
--- a/example2.c
+++ b/example2.c
@@ -10,7 +10,7 @@ void main(void)        /*  Textcount.c  */
     {
         int pid;
         int p[2], q[2];
-        FILE *fdopen, *fp;
+        FILE *fp;
         char c;
         int newline = TRUE;
         int total;


### PR DESCRIPTION
Короче если это не убрать, то fdopen() вызвать не получится.
Что логично.